### PR TITLE
Add default record mapping in mapping policy, initial id map in upload options

### DIFF
--- a/src/AutoMigrator.ts
+++ b/src/AutoMigrator.ts
@@ -28,7 +28,6 @@ export class AutoMigrator extends EventEmitter {
   async loadCSVData(
     inputs: UploadInput[],
     mappingPolicies: RecordMappingPolicy[] = [],
-    initialIdMap: Map<string, string> = new Map<string, string>(),
     options: UploadOptions = {},
   ) {
     const conn = this._conn;
@@ -36,7 +35,6 @@ export class AutoMigrator extends EventEmitter {
       conn,
       inputs,
       mappingPolicies,
-      initialIdMap,
       (params) => {
         this.emit('loadProgress', params);
       },

--- a/src/AutoMigrator.ts
+++ b/src/AutoMigrator.ts
@@ -28,6 +28,7 @@ export class AutoMigrator extends EventEmitter {
   async loadCSVData(
     inputs: UploadInput[],
     mappingPolicies: RecordMappingPolicy[] = [],
+    initialIdMap: Map<string, string> = new Map<string, string>(),
     options: UploadOptions = {},
   ) {
     const conn = this._conn;
@@ -35,6 +36,7 @@ export class AutoMigrator extends EventEmitter {
       conn,
       inputs,
       mappingPolicies,
+      initialIdMap,
       (params) => {
         this.emit('loadProgress', params);
       },

--- a/src/load.ts
+++ b/src/load.ts
@@ -388,7 +388,7 @@ async function getAllExistingIdMap(
   conn: Connection,
   datasets: LoadDataset[],
   mappingPolicies: RecordMappingPolicy[],
-  initialIdMap: Map<string, string>,
+  initialIdMap: Map<string, string> = new Map<string, string>(),
   describer: Describer,
 ) {
   const datasetMap = new Map(
@@ -433,7 +433,6 @@ async function upload(
   conn: Connection,
   datasets: LoadDataset[],
   mappingPolicies: RecordMappingPolicy[],
-  initialIdMap: Map<string, string>,
   reportProgress: (progress: UploadProgress) => void,
   options: UploadOptions,
 ) {
@@ -445,7 +444,7 @@ async function upload(
     conn,
     datasets,
     mappingPolicies,
-    initialIdMap,
+    options.idMap,
     describer,
   );
   const uploadStatus = {
@@ -497,17 +496,9 @@ export async function loadCSVData(
   conn: Connection,
   inputs: UploadInput[],
   mappingPolicies: RecordMappingPolicy[],
-  initialIdMap: Map<string, string>,
   reportUpload: (status: UploadProgress) => void,
   options: UploadOptions = {},
 ) {
   const datasets = await parseCSVInputs(inputs, options);
-  return upload(
-    conn,
-    datasets,
-    mappingPolicies,
-    initialIdMap,
-    reportUpload,
-    options,
-  );
+  return upload(conn, datasets, mappingPolicies, reportUpload, options);
 }

--- a/src/load.ts
+++ b/src/load.ts
@@ -7,6 +7,7 @@ import {
   UploadProgress,
   RecordMappingPolicy,
   UploadOptions,
+  RecordSpecifier,
 } from './types';
 import { describeSObjects, Describer } from './describe';
 
@@ -281,6 +282,7 @@ async function getExistingIdMap(
   conn: Connection,
   dataset: LoadDataset,
   keyFields: string[],
+  defaultMapping: RecordSpecifier | undefined,
   describer: Describer,
 ) {
   const idMap = new Map<string, string>();
@@ -298,56 +300,81 @@ async function getExistingIdMap(
       idIndex = i;
     }
   }
-  if (idIndex < 0 || keyIndexMap.size === 0) {
+  if (idIndex < 0) {
     return idMap;
   }
-  const keyMap = new Map<string, string>();
-  const keyFieldConditionValues = new Map<string, Set<any>>();
-  for (const row of rows) {
-    const id = row[idIndex];
-    if (id != null && id !== '') {
-      const keyValueTpl = [];
-      for (const keyField of keyFields) {
-        const keyIndex = keyIndexMap.get(keyField);
-        const keyFieldValue = keyIndex != null ? row[keyIndex] : null;
-        const keyFieldValues =
-          keyFieldConditionValues.get(keyField) ?? new Set<any>();
-        keyFieldValues.add(keyFieldValue ?? null);
-        keyFieldConditionValues.set(keyField, keyFieldValues);
-        keyValueTpl.push(keyFieldValue ?? '');
+  if (keyIndexMap.size > 0) {
+    const keyMap = new Map<string, string>();
+    const keyFieldConditionValues = new Map<string, Set<any>>();
+    for (const row of rows) {
+      const id = row[idIndex];
+      if (id != null && id !== '') {
+        const keyValueTpl = [];
+        for (const keyField of keyFields) {
+          const keyIndex = keyIndexMap.get(keyField);
+          const keyFieldValue = keyIndex != null ? row[keyIndex] : null;
+          const keyFieldValues =
+            keyFieldConditionValues.get(keyField) ?? new Set<any>();
+          keyFieldValues.add(keyFieldValue ?? null);
+          keyFieldConditionValues.set(keyField, keyFieldValues);
+          keyValueTpl.push(keyFieldValue ?? '');
+        }
+        const keyValue = keyValueTpl.join('\t').trim();
+        keyMap.set(keyValue, id);
       }
-      const keyValue = keyValueTpl.join('\t').trim();
-      keyMap.set(keyValue, id);
+    }
+    const condition = Array.from(keyFieldConditionValues.keys()).reduce(
+      (cond, keyField) => {
+        const fieldValues = keyFieldConditionValues.get(keyField);
+        return fieldValues
+          ? { ...cond, [keyField]: Array.from(fieldValues) }
+          : cond;
+      },
+      {},
+    );
+    const records: SFRecord[] =
+      keyMap.size === 0
+        ? []
+        : await conn.sobject(object).find(condition, ['Id', ...keyFields]);
+    const newKeyMap = new Map<string, string>();
+    for (const record of records) {
+      const keyValue = keyFields
+        .map((keyField) => record[keyField])
+        .join('\t')
+        .trim();
+      if (keyValue != null) {
+        newKeyMap.set(keyValue, record.Id as string);
+      }
+    }
+    for (const keyValue of keyMap.keys()) {
+      const id = keyMap.get(keyValue);
+      const newId = newKeyMap.get(keyValue);
+      if (id != null && newId != null) {
+        idMap.set(id, newId);
+      }
     }
   }
-  const condition = Array.from(keyFieldConditionValues.keys()).reduce(
-    (cond, keyField) => {
-      const fieldValues = keyFieldConditionValues.get(keyField);
-      return fieldValues
-        ? { ...cond, [keyField]: Array.from(fieldValues) }
-        : cond;
-    },
-    {},
-  );
-  const records: SFRecord[] =
-    keyMap.size === 0
-      ? []
-      : await conn.sobject(object).find(condition, ['Id', ...keyFields]);
-  const newKeyMap = new Map<string, string>();
-  for (const record of records) {
-    const keyValue = keyFields
-      .map((keyField) => record[keyField])
-      .join('\t')
-      .trim();
-    if (keyValue != null) {
-      newKeyMap.set(keyValue, record.Id as string);
+  if (defaultMapping) {
+    let defaultId: string | undefined = undefined;
+    if (typeof defaultMapping === 'string') {
+      defaultId = defaultMapping;
+    } else {
+      const { condition, orderby, offset } = defaultMapping;
+      let soql = `SELECT Id FROM ${object}`;
+      soql += condition ? ` WHERE ${condition}` : '';
+      soql += orderby ? ` ORDER BY ${orderby}` : '';
+      soql += ` LIMIT 1`;
+      soql += offset ? ` OFFSET ${offset}` : '';
+      const { records } = await conn.query<{ Id: string }>(soql);
+      defaultId = records?.[0]?.Id;
     }
-  }
-  for (const keyValue of keyMap.keys()) {
-    const id = keyMap.get(keyValue);
-    const newId = newKeyMap.get(keyValue);
-    if (id != null && newId != null) {
-      idMap.set(id, newId);
+    if (defaultId) {
+      for (const row of rows) {
+        const id = row[idIndex];
+        if (id && !idMap.has(id)) {
+          idMap.set(id, defaultId);
+        }
+      }
     }
   }
   return idMap;
@@ -367,7 +394,13 @@ async function getAllExistingIdMap(
   );
   const idMap = (
     await Promise.all(
-      mappingPolicies.map(({ object, keyField, keyFields: keyFields_ }) => {
+      mappingPolicies.map((policy) => {
+        const {
+          object,
+          keyField,
+          keyFields: keyFields_,
+          defaultMapping,
+        } = policy;
         const dataset = datasetMap.get(object);
         if (!dataset) {
           throw new Error(`Input is not found for mapping object: ${object}`);
@@ -378,13 +411,14 @@ async function getAllExistingIdMap(
             : keyFields_
           : keyField
           ? [keyField]
-          : undefined;
-        if (!keyFields) {
-          throw new Error(
-            `Key field is not specified for mapping object: ${object}`,
-          );
-        }
-        return getExistingIdMap(conn, dataset, keyFields, describer);
+          : [];
+        return getExistingIdMap(
+          conn,
+          dataset,
+          keyFields,
+          defaultMapping,
+          describer,
+        );
       }),
     )
   ).reduce(

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,8 @@ export type UploadInput = {
 
 export type RecordMappingPolicy = {
   object: string;
-  keyField: string;
+  keyField?: string;
+  keyFields?: string | string[];
 };
 
 export type UploadStatus = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export type UploadStatus = {
     blockingField: string | undefined;
     blockingId: string | undefined;
   }>;
+  idMap: Map<string, string>;
 };
 
 export type UploadResult = UploadStatus;

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export type UploadProgress = {
 
 export type UploadOptions = {
   defaultNamespace?: string;
+  idMap?: Map<string, string>;
 };
 
 export type RelatedTarget = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,17 @@ export type RecordMappingPolicy = {
   object: string;
   keyField?: string;
   keyFields?: string | string[];
+  defaultMapping?: RecordSpecifier;
 };
+
+export type RecordSpecifier =
+  | string
+  | {
+      condition?: string;
+      orderby?: string;
+      offset?: number;
+      scope?: string;
+    };
 
 export type UploadStatus = {
   totalCount: number;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -240,6 +240,39 @@ ${USER_IDS[1]}
     expect(idMap.size).toBe(5);
   });
 
+  it('should upload data with existing id map', async () => {
+    const am = new AutoMigrator(conn);
+    const { user_id: userId } = await conn.identity();
+    const {
+      totalCount,
+      successes,
+      failures,
+      blocked,
+      idMap,
+    } = await am.loadCSVData(
+      [
+        {
+          object: 'Account',
+          csvData: `
+Id,Name,OwnerId
+${ACCOUNT_IDS[0]},Account 01,${USER_IDS[0]}
+        `.trim(),
+        },
+      ],
+      undefined,
+      new Map([[USER_IDS[0], userId]]),
+    );
+    expect(totalCount).toBe(1);
+    expect(successes).toBeDefined();
+    expect(successes.length).toBe(1);
+    expect(failures).toBeDefined();
+    expect(failures.length).toBe(0);
+    expect(blocked).toBeDefined();
+    expect(blocked.length).toBe(0);
+    expect(idMap).toBeDefined();
+    expect(idMap.size).toBe(2);
+  });
+
   it('should upload data from csv', async () => {
     const accCnt = await conn.sobject('Account').count();
     const oppCnt = await conn.sobject('Opportunity').count();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -260,7 +260,7 @@ ${ACCOUNT_IDS[0]},Account 01,${USER_IDS[0]}
         },
       ],
       undefined,
-      new Map([[USER_IDS[0], userId]]),
+      { idMap: new Map([[USER_IDS[0], userId]]) },
     );
     expect(totalCount).toBe(1);
     expect(successes).toBeDefined();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -123,6 +123,123 @@ ${CONTACT_IDS[0]},Sarah,Connor,${ACCOUNT_IDS[0]}
     expect(idMap.size).toBe(0);
   });
 
+  it('should upload data with mapping policy', async () => {
+    const am = new AutoMigrator(conn);
+    const ret1 = await conn
+      .sobject('Account')
+      .create({ Name: 'Account 01', Website: 'example.com' });
+    const ret2 = await conn
+      .sobject('Account')
+      .create({ Name: 'Account 01', Website: 'example.net' });
+    const aid1 = ret1.success ? ret1.id : null;
+    const aid2 = ret2.success ? ret2.id : null;
+    if (!aid1 || !aid2) {
+      throw new Error('Account creation failed');
+    }
+    const {
+      totalCount,
+      successes,
+      failures,
+      blocked,
+      idMap,
+    } = await am.loadCSVData(
+      [
+        {
+          object: 'Contact',
+          csvData: `
+Id,FirstName,LastName,AccountId
+${CONTACT_IDS[0]},John,Doe,${ACCOUNT_IDS[0]}
+${CONTACT_IDS[1]},Jane,Doe,${ACCOUNT_IDS[0]}
+        `.trim(),
+        },
+        {
+          object: 'Account',
+          csvData: `
+Id,Name,Website
+${ACCOUNT_IDS[0]},Account 01,example.com
+        `.trim(),
+        },
+      ],
+      [
+        {
+          object: 'Account',
+          keyFields: ['Name', 'Website'],
+        },
+      ],
+    );
+    expect(totalCount).toBe(3);
+    expect(successes).toBeDefined();
+    expect(successes.length).toBe(2);
+    expect(failures).toBeDefined();
+    expect(failures.length).toBe(0);
+    expect(blocked).toBeDefined();
+    expect(blocked.length).toBe(0);
+    expect(idMap).toBeDefined();
+    expect(idMap.size).toBe(3);
+    expect(idMap.get(ACCOUNT_IDS[0])).toBe(aid1);
+  });
+
+  it('should upload data with default record mapping', async () => {
+    const am = new AutoMigrator(conn);
+    const { user_id: userId } = await conn.identity();
+    await conn.sobject('Account').create({ Name: 'Existing Account' });
+    const {
+      totalCount,
+      successes,
+      failures,
+      blocked,
+      idMap,
+    } = await am.loadCSVData(
+      [
+        {
+          object: 'Contact',
+          csvData: `
+Id,FirstName,LastName,AccountId,OwnerId
+${CONTACT_IDS[0]},John,Doe,${ACCOUNT_IDS[0]},${USER_IDS[0]}
+${CONTACT_IDS[1]},Jane,Doe,${ACCOUNT_IDS[0]},${USER_IDS[1]}
+        `.trim(),
+        },
+        {
+          object: 'Account',
+          csvData: `
+Id
+${ACCOUNT_IDS[0]}
+        `.trim(),
+        },
+        {
+          object: 'User',
+          csvData: `
+Id
+${USER_IDS[0]}
+${USER_IDS[1]}
+        `.trim(),
+        },
+      ],
+      [
+        {
+          object: 'Account',
+          defaultMapping: {
+            condition: "Name = 'Existing Account'",
+            orderby: 'CreatedDate DESC',
+          },
+        },
+        {
+          object: 'User',
+          defaultMapping: userId,
+        },
+      ],
+    );
+    expect(totalCount).toBe(5);
+    expect(successes).toBeDefined();
+    expect(successes.length).toBe(2);
+    expect(failures).toBeDefined();
+    expect(failures.length).toBe(0);
+    expect(blocked).toBeDefined();
+    expect(blocked.length).toBe(0);
+    expect(idMap).toBeDefined();
+    expect(idMap.size).toBe(5);
+  });
+
   it('should upload data from csv', async () => {
     const accCnt = await conn.sobject('Account').count();
     const oppCnt = await conn.sobject('Opportunity').count();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -44,7 +44,7 @@ describe('AutoMigrator', () => {
     const mappingPolicies = [
       {
         object: 'User',
-        keyField: 'FederationIdentifier',
+        keyFields: ['FederationIdentifier'],
       },
     ];
     am.on('loadProgress', ({ totalCount, successCount, failureCount }) => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -20,11 +20,22 @@ describe('AutoMigrator', () => {
 
   it('should upload empty data', async () => {
     const am = new AutoMigrator(conn);
-    const { successes, failures } = await am.loadCSVData([]);
+    const {
+      totalCount,
+      successes,
+      failures,
+      blocked,
+      idMap,
+    } = await am.loadCSVData([]);
+    expect(totalCount).toBe(0);
     expect(successes).toBeDefined();
     expect(successes.length).toBe(0);
     expect(failures).toBeDefined();
     expect(failures.length).toBe(0);
+    expect(blocked).toBeDefined();
+    expect(blocked.length).toBe(0);
+    expect(idMap).toBeDefined();
+    expect(idMap.size).toBe(0);
   });
 
   it('should upload data from csv', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -15,6 +15,13 @@ beforeAll(async () => {
 /**
  *
  */
+const ACCOUNT_IDS = ['0012800000k4FHkAAM'];
+const CONTACT_IDS = ['0032v00003J3g3PAAR', '0032v00003VNQLtAAP'];
+const USER_IDS = ['00528000002J6BkAAK', '0052v00000g3SEkAAM'];
+
+/**
+ *
+ */
 describe('AutoMigrator', () => {
   jest.setTimeout(300000);
 
@@ -51,7 +58,7 @@ describe('AutoMigrator', () => {
         object: 'Account',
         csvData: `
 Id,Name,OwnerId
-0012800000k4FHkAAM,Account 01,00528000002J6BkAAK
+${ACCOUNT_IDS[0]},Account 01,${USER_IDS[0]}
         `.trim(),
       },
       {
@@ -67,9 +74,9 @@ Id,Name,OwnerId
     expect(blocked).toBeDefined();
     expect(blocked.length).toBe(1);
     expect(blocked[0].object).toBe('Account');
-    expect(blocked[0].origId).toBe('0012800000k4FHkAAM');
+    expect(blocked[0].origId).toBe(ACCOUNT_IDS[0]);
     expect(blocked[0].blockingField).toBe('OwnerId');
-    expect(blocked[0].blockingId).toBe('00528000002J6BkAAK');
+    expect(blocked[0].blockingId).toBe(USER_IDS[0]);
     expect(idMap).toBeDefined();
     expect(idMap.size).toBe(0);
   });
@@ -84,18 +91,18 @@ Id,Name,OwnerId
       idMap,
     } = await am.loadCSVData([
       {
-        // account with no name field will fail
+        // account with no name field (will fail to load)
         object: 'Account',
         csvData: `
 Id,Name,Type
-0012800000k4FHkAAM,,Partner
+${ACCOUNT_IDS[0]},,Partner
         `.trim(),
       },
       {
         object: 'Contact',
         csvData: `
 Id,FirstName,LastName,AccountId
-0032v00003J3g3PAAR,Sarah,Connor,0012800000k4FHkAAM
+${CONTACT_IDS[0]},Sarah,Connor,${ACCOUNT_IDS[0]}
         `.trim(),
       },
     ]);
@@ -105,13 +112,13 @@ Id,FirstName,LastName,AccountId
     expect(failures).toBeDefined();
     expect(failures.length).toBe(1);
     expect(failures[0].object).toBe('Account');
-    expect(failures[0].origId).toBe('0012800000k4FHkAAM');
+    expect(failures[0].origId).toBe(ACCOUNT_IDS[0]);
     expect(blocked).toBeDefined();
     expect(blocked.length).toBe(1);
     expect(blocked[0].object).toBe('Contact');
-    expect(blocked[0].origId).toBe('0032v00003J3g3PAAR');
+    expect(blocked[0].origId).toBe(CONTACT_IDS[0]);
     expect(blocked[0].blockingField).toBe('AccountId');
-    expect(blocked[0].blockingId).toBe('0012800000k4FHkAAM');
+    expect(blocked[0].blockingId).toBe(ACCOUNT_IDS[0]);
     expect(idMap).toBeDefined();
     expect(idMap.size).toBe(0);
   });


### PR DESCRIPTION
- accept default record mapping (by static id and query) when no matching fields found
- accept existing id map in upload options