### PR TITLE
Add option to ignore system date / readonly fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-migration-automatic",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-migration-automatic",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Migrate data from an org to another org, by exporting/importing data as CSVs",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,12 +83,16 @@ export type DumpQuery = {
   object: string;
   fields?: string | string[];
   ignoreFields?: string | string[];
+  ignoreSystemDate?: boolean;
+  ignoreReadOnly?: boolean;
 } & DumpTarget;
 
 export type DumpOptions = {
   defaultNamespace?: string;
   maxFetchSize?: number;
   idMap?: Map<string, string>;
+  ignoreSystemDate?: boolean;
+  ignoreReadOnly?: boolean;
 };
 
 export type DumpProgress = {


### PR DESCRIPTION
In dump option and dump query, add `ignoreSystemDate` and `ignoreReadOnly` boolean option, the first one excludes the system date (CreatedDate, LastModifiedDate, etc.) in dump data, and the second excludes readonly fields except for the record ID.